### PR TITLE
If I use a json library to decoce payload, it may crash

### DIFF
--- a/lib/fireworks/channel.ex
+++ b/lib/fireworks/channel.ex
@@ -145,9 +145,17 @@ defmodule Fireworks.Channel do
       def handle_info({:basic_deliver, payload, %{delivery_tag: tag, redelivered: redelivered} = meta}, %{channel: channel} = s) do
         # Handle Message Distribution
         #Logger.debug "AMQP Delivered Payload: #{inspect payload}"
+        payload = 
         if s.json_library != nil do
-          payload = payload
-            |> s.json_library.decode!(s.json_opts)
+          try do
+            payload
+              |> s.json_library.decode!(s.json_opts)
+          rescue
+            any ->
+              payload
+          end
+        else
+          payload
         end
 
         task = Task.async(fn -> consume(payload, meta) end)


### PR DESCRIPTION
Dear author

I use "fireworks" as a part of my project. But I notice that it crashes sometime, because I use a json library and the library can't decode the payload.
So I modify the code to avoid this happen again.
