### PR TITLE
introduce a new Consumer pattern

### DIFF
--- a/lib/fireworks/consumer.ex
+++ b/lib/fireworks/consumer.ex
@@ -1,0 +1,140 @@
+# TODO how do we handle graceful shutdown? We need to send a Basic.cancel and wait for tasks to finish before actually terminating
+defmodule Fireworks.Consumer do
+  use GenServer
+  alias AMQP.{Basic,Channel,Confirm,Connection,Exchange,Queue}
+  require Logger
+
+  @default_opts %{
+    prefetch: 5,
+    reconnect_after_ms: 1_000,
+    setup_fn: nil, # replaced with default fn in init
+    task_timeout: 60_000,
+  }
+
+  def start_link(opts, genserver_opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, genserver_opts)
+  end
+
+  def ack(%{consumer: consumer}=meta) do
+    GenServer.call(consumer, {:ack, meta})
+  end
+
+  def reject(%{consumer: consumer}=meta, opts \\ []) do
+    GenServer.call(consumer, {:reject, meta, opts})
+  end
+
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    send(self(), :connect)
+    opts = @default_opts |> Map.put(:setup_fn, fn(_chan) -> :nothing end) |> Map.merge(opts)
+    state = %{
+      channel: nil,
+      consumer_tag: nil,
+      tasks: [],
+      opts: opts,
+      status: :disconnected,
+    }
+    {:ok, state}
+  end
+
+  def handle_info(:connect, s) do
+    Logger.debug("attempting to connect to #{s.opts.queue}")
+    case attempt_to_connect(s) do
+      {:ok, chan, consumer_tag} ->
+        {:noreply, %{s | channel: chan, consumer_tag: consumer_tag, status: :connected}}
+      {:error, :disconnected} ->
+        :timer.send_after(s.opts.reconnect_after_ms, :connect)
+        {:noreply, %{s | channel: nil, consumer_tag: nil, status: :disconnected}}
+    end
+  end
+
+  def handle_call({:ack, %{channel: chan, delivery_tag: tag}}, _from, %{channel: chan} = s) do
+    response = Basic.ack(chan, tag)
+    {:reply, response, s}
+  end
+  def handle_call({:ack, _meta}, _from, s) do
+    {:reply, {:error, "no longer connected to that channel"}, s}
+  end
+
+  def handle_call({:reject, %{channel: chan, delivery_tag: tag}, opts}, _from, %{channel: chan} = s) do
+    response = Basic.reject(chan, tag, opts)
+    {:reply, response, s}
+  end
+  def handle_call({:reject, _meta, _opts}, _from, s) do
+    {:reply, {:error, "no longer connected to that channel"}, s}
+  end
+
+  # Confirmation sent by the broker after registering this process as a consumer
+  def handle_info({:basic_consume_ok, %{consumer_tag: consumer_tag}}, s) do
+    {:noreply, s}
+  end
+
+  # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
+  def handle_info({:basic_cancel, %{consumer_tag: consumer_tag}}, s) do
+    {:stop, :normal, %{s | state: :disconnected, channel: nil}}
+  end
+
+  # Confirmation sent by the broker to the consumer process after a Basic.cancel
+  def handle_info({:basic_cancel_ok, %{consumer_tag: consumer_tag}}, s) do
+    {:stop, :normal, %{s | state: :disconnected, channel: nil}}
+  end
+
+  def handle_info({:basic_deliver, payload, %{delivery_tag: tag, redelivered: redelivered} = meta}, %{channel: channel} = s) do
+    meta = meta |> Map.put(:channel, channel) |> Map.put(:consumer, self())
+    task = Task.async(fn -> s.opts.consume_fn.(payload, meta) end)
+
+    Process.unlink(task.pid)
+    timer_ref = :erlang.start_timer(s.opts.task_timeout, self(), {:task_timeout, task, tag, redelivered, payload})
+
+    {:noreply, %{s | tasks: [{task, timer_ref, meta} | s.tasks]}}
+  end
+
+  def handle_info({task, _}, %{tasks: tasks} = s) when is_reference(task) do
+    {finished_tasks, remaining_tasks} = Enum.partition(tasks, fn({%{ref: ref}, _, _}) -> ref == task end)
+    Enum.each(finished_tasks, fn({_, timer_ref, _}) ->
+      :erlang.cancel_timer(timer_ref)
+    end)
+
+    {:noreply, %{s | tasks: remaining_tasks}}
+  end
+
+  def handle_info({:EXIT, pid, reason}, s) do
+    Logger.debug("got EXIT from #{inspect pid} (#{inspect reason})")
+    {:noreply, s}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, reason}, %{channel: %{pid: chan_pid}} = s) when pid == chan_pid do
+    send(self, :connect)
+    {:noreply, %{s | status: :disconnected, channel: nil}}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, :normal}, s) do
+    {:noreply, s}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, error}, s) do
+    {error_tasks, remaining_tasks} = Enum.partition(s.tasks, fn({%{ref: task_ref}, timer_ref, meta}) -> task_ref == ref end)
+    Enum.each(error_tasks, fn({task, timer_ref, meta}) ->
+      :erlang.cancel_timer(timer_ref)
+      # TODO make the `requeue` option configurable?
+      Basic.reject s.channel, meta.delivery_tag, requeue: false
+    end)
+    {:noreply, %{s | tasks: remaining_tasks}}
+  end
+
+  def handle_info({:timeout, timer_ref, {:task_timeout, %{pid: task_pid, ref: task_ref}, tag, redelivered, payload}}, %{channel: channel} = s) do
+    Process.exit(task_pid, :task_timeout)
+    {:noreply, s}
+  end
+
+  defp attempt_to_connect(state) do
+     Fireworks.with_conn(Fireworks.ConnPool, fn conn ->
+        {:ok, chan} = Channel.open(conn)
+        Process.monitor(chan.pid)
+        state.opts.setup_fn.(chan)
+        :ok = Basic.qos(chan, prefetch_count: state.opts.prefetch)
+        {:ok, consumer_tag} = Basic.consume(chan, state.opts.queue, self())
+        {:ok, chan, consumer_tag}
+      end)
+  end
+end


### PR DESCRIPTION
This is a proposal to provide an alternative to the current pattern of the `Fireworks.Channel` subscriber.

__The Use Case__

I have an application that will need to subscriber to 38 queues. 33 of the queues are just triplets of `created`, `updated` and `deleted` queues for a given resource type. Rather than write (or generate) 38 unique modules in my project I would like to setup a supervisor that supervises 38 consumer processes each of which are subscribed to a given queue and consume the messages by calling a function like `MyApp.BudgetSubscriber.created`.

<details>
  <summary>Screenshot showing queue pattern</summary>
  <img src="https://cloud.githubusercontent.com/assets/80008/24879528/77fedd92-1df4-11e7-9398-b8d94dcef3c6.png" rel="screenshot showing queues" />
</details>

__The Implementation__

This is mostly a re-write of the `Fireworks.Channel` pattern, except that it replaces the module-level callbacks with functions that can be passed in when standing up a supervision tree.

This also changes a few other behaviors:
* `ack` and `reject` are now synchronous using `GenServer.call` instead of `GenServer.cast`. This way if you try to ack a message twice you'll get an error in the consuming code.
* `ack` and `reject` are called with a full copy of the `meta` parameter rather than pulling the delivery tag out of it. This avoids the problem where after a connection recovery someone tries to ack a message that was received from the old connection/channel. RabbitMQ will forcibly shut down your channel if you try to ack a delivery tag that hasn't been given to your channel, or even worse you might successfully `ack` a delivery tag that has been received under the new connection, causing a very confusing double-ack problem. To avoid this we send back both the `channel` and the `delivery_tag` so we can return an error if someone tries to send back an `ack` or `reject` for a message received under an old channel.
* removed the `publish` function which was just a proxy to `Fireworks.publish`
* removed the automatic JSON decoding. I can definitely add this back in, but it looks like there have been a lot of reported issues around this feature. Maybe it's best to let client code handle the encoding/decoding and we just handle availability and delivery of messages?

__Usage__

In my application I would use this by doing something like:

```elixir
children = [
  worker(Fireworks.Consumer, [%{
    queue: "brokaw.abacus.budget.created",
    prefetch: 2,
    consume_fn: &Brokaw.BudgetSubscriber.created/2,
    setup_fn: fn(channel) ->
      Queue.declare(channel, "brokaw.abacus.budget.created", durable: false)
      Queue.bind(channel, "brokaw.abacus.budget.created", "events", routing_key: "abacus.budget.created")
    end},
    [name: :budget_created]],
    [id: :budget_created])
```

That's a bit of a mouthful, but it lets me pass in all of my parameters as data so I can create helper functions to generate most of that data and easily test those functions.

Is this a pattern that looks palatable to the `fireworks` community? For my application this makes it easy for me to generate all 38 subscriptions with ~20 lines of code since they follow a naming convention and I can easily do all the configuration at runtime instead of splitting it across my module and my config files. I realize of course that my use-case is specific to my company/application so I can totally understand if this isn't a direction that `fireworks` wants to go.

/cc @ewitchin 