### PR TITLE
allow configuring multiple hosts

### DIFF
--- a/lib/fireworks/connection.ex
+++ b/lib/fireworks/connection.ex
@@ -29,7 +29,8 @@ defmodule Fireworks.Connection do
   end
 
   def handle_info(:connect, s) do
-    case Connection.open(s.opts) do
+    opts = connection_options(s.opts)
+    case Connection.open(opts) do
       {:ok, conn} ->
         Process.monitor(conn.pid)
         {:noreply, %{s | conn: conn, status: :connected}}
@@ -61,4 +62,12 @@ defmodule Fireworks.Connection do
     :ok
   end
 
+  defp connection_options(opts) do
+    case Keyword.get(opts, :hosts) do
+      nil -> opts
+      hosts when is_list(hosts) ->
+        host = Enum.random(hosts)
+        opts |> Keyword.delete(:hosts) |> Keyword.put(:host, host)
+    end
+  end
 end


### PR DESCRIPTION
When a connection is being established we can randomly pick one of the specified hosts. This allows users to specify all the hosts in their rabbitmq cluster and if one goes down for maintenance they can reconnect to another host in the cluster.

```
config :fireworks, :connection, hosts: ["rabbit1","rabbit2","rabbit3"],
                                username: "myuser",
                                password: "mypass"
```

/cc @ewitchin 