### PR TITLE
typo on handling basic_cancel

### DIFF
--- a/lib/fireworks/consumer.ex
+++ b/lib/fireworks/consumer.ex
@@ -72,13 +72,13 @@ defmodule Fireworks.Consumer do
   # Sent by the broker when the consumer is unexpectedly cancelled (such as after a queue deletion)
   def handle_info({:basic_cancel, %{consumer_tag: _consumer_tag}}, s) do
     Logger.error("the #{s.opts.queue} consumer was cancelled by the broker (basic_cancel)")
-    {:stop, :normal, %{s | state: :disconnected, channel: nil}}
+    {:stop, :normal, %{s | status: :disconnected, channel: nil}}
   end
 
   # Confirmation sent by the broker to the consumer process after a Basic.cancel
   def handle_info({:basic_cancel_ok, %{consumer_tag: _consumer_tag}}, s) do
     Logger.error("the #{s.opts.queue} consumer was cancelled by the broker (basic_cancel_ok)")
-    {:stop, :normal, %{s | state: :disconnected, channel: nil}}
+    {:stop, :normal, %{s | status: :disconnected, channel: nil}}
   end
 
   def handle_info({:basic_deliver, payload, %{delivery_tag: tag, redelivered: redelivered} = meta}, %{channel: channel} = s) do


### PR DESCRIPTION
This was a typo when I copied things over into the consumer proposal. This should be updating the `status` key to mark the consumer as disconnected.

Sorry for the derpy typo.

You can reproduce this in the `0.6.0` release by starting a consumer and then manually deleting the queue in the rabbitmq admin interface. You should see a SASL report like this:

```
[error] GenServer :"brokaw.abacus.budget.created" terminating
** (KeyError) key :state not found
    (fireworks) lib/fireworks/consumer.ex:75: Fireworks.Consumer.handle_info/2
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:basic_cancel, %{consumer_tag: "amq.ctag-we92qu19mvwZsHV-ztTbtw", no_wait: true}}
State: %{channel: %AMQP.Channel{conn: %AMQP.Connection{pid: #PID<0.542.0>}, pid: #PID<0.605.0>}, consumer_tag: "amq.ctag-we92qu19mvwZsHV-ztTbtw", opts: %{consume_fn: #Function<0.30024238/2 in Brokaw.Subscriber.at_most_once_consumer/3>, prefetch: 50, queue: "brokaw.abacus.budget.created", reconnect_after_ms: 1000, setup_fn: #Function<1.30024238/1 in Brokaw.Subscriber.setup_queue/2>, task_timeout: 60000}, status: :connected, tasks: []}
```

With this patch applied the consumer process exits normally after a basic cancel from the broker